### PR TITLE
remove unused script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
     "build": "tsc -p tsconfig.app.json && vite build && youtrack-app validate dist",
     "lint": "eslint --report-unused-disable-directives --max-warnings 0",
     "pack": "rm -f embedded-sites.zip && (cd dist && npx bestzip ../embedded-sites.zip .)",


### PR DESCRIPTION
Removes unused 'dev' script from JavaScript project configuration to streamline package management and prevent unnecessary script execution.
