### PR TITLE
chore: bump version to 1.1.1 and update npm dependencies

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "embedded-sites",
   "title": "Embedded Sites",
   "description": "To embed different sites with widgets to dashboards.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "vendor": {
     "name": "J&J Ideenschmiede GmbH",
     "url": "https://jj-ideenschmiede.de",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "youtrack-embedded-sites-app",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "youtrack-embedded-sites-app",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@jetbrains/ring-ui-built": "^7.0.8",
         "core-js": "3.48.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "youtrack-embedded-sites-app",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.app.json && vite build && youtrack-app validate dist",


### PR DESCRIPTION
## Summary

- Bump version to 1.1.1 in `package.json` and `manifest.json`
- Bump `core-js` from 3.38.0 to 3.48.0
- Bump `@eslint/compat` from 1.x to 2.x
- Bump `eslint-plugin-react-hooks` from 5.x to 7.x
- Bump `globals` from 16.x to 17.x
- Update all remaining packages within existing semver ranges
- Fix `hostRef.current` access during render (`react-hooks/refs` rule)

## Test plan

- [x] `npm run lint` passes without errors
- [x] `npm run build` succeeds and manifest is valid

🤖 Generated with Claude Code